### PR TITLE
US221: Convert Main Screen to Spanish

### DIFF
--- a/components/DrawerNavigator.js
+++ b/components/DrawerNavigator.js
@@ -5,7 +5,7 @@ import StackNavigator from './StackNavigator';
 import NavigationService from './NavigationService';
 import ResourceStack from './ResourceStack';
 import GlossaryStack from './GlossaryStack';
-import { translate } from './translateService';
+import translate from './translateService';
 
 // DrawerNavigator: user opens using button on the top left of the header
 // Drawer slides out from the side and contains components listed below

--- a/components/DrawerNavigator.js
+++ b/components/DrawerNavigator.js
@@ -5,13 +5,24 @@ import StackNavigator from './StackNavigator';
 import NavigationService from './NavigationService';
 import ResourceStack from './ResourceStack';
 import GlossaryStack from './GlossaryStack';
+import * as Localization from 'expo-localization';
+import i18n from 'i18n-js';
+
+i18n.locale = Localization.locale;
+i18n.fallbacks = true;
 
 // DrawerNavigator: user opens using button on the top left of the header
 // Drawer slides out from the side and contains components listed below
 const DrawerNav = createDrawerNavigator({
-    Home: StackNavigator,
-    Resources: ResourceStack,
-    Glossary: GlossaryStack
+    Home: {
+        screen: StackNavigator,
+            navigationOptions: ()=> ({title: i18n.t('Home')}) }, 
+    Resources: {
+        screen: ResourceStack,
+            navigationOptions: ()=> ({title: i18n.t('Resources')}) },
+    Glossary: {
+        screen: GlossaryStack,
+            navigationOptions: ()=> ({title: i18n.t('Glossary')}) }
 });
 
 // New in this version of React Native, must be referenced/returned
@@ -26,3 +37,8 @@ export default class DrawerNavigator extends Component {
           }}/>;
     }
 }
+
+i18n.translations = {
+    en: { Home: 'Home', Resources:  'Resources', Glossary: 'Glossary', PediatricPTSD: 'Pediatric PTSD', more:'more'},
+    es: { Home: 'Hogar', Resources: 'Recursos', Glossary: 'Glosario', PediatricPTSD: 'Pediátrico TEPT', more: 'más'},
+  };

--- a/components/DrawerNavigator.js
+++ b/components/DrawerNavigator.js
@@ -5,24 +5,20 @@ import StackNavigator from './StackNavigator';
 import NavigationService from './NavigationService';
 import ResourceStack from './ResourceStack';
 import GlossaryStack from './GlossaryStack';
-import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
-
-i18n.locale = Localization.locale;
-i18n.fallbacks = true;
+import { translate } from './translateService';
 
 // DrawerNavigator: user opens using button on the top left of the header
 // Drawer slides out from the side and contains components listed below
 const DrawerNav = createDrawerNavigator({
     Home: {
         screen: StackNavigator,
-            navigationOptions: ()=> ({title: i18n.t('Home')}) }, 
+            navigationOptions: ()=> ({title: translate('drawerNavigator.home')}) }, 
     Resources: {
         screen: ResourceStack,
-            navigationOptions: ()=> ({title: i18n.t('Resources')}) },
+            navigationOptions: ()=> ({title: translate('drawerNavigator.resources')}) },
     Glossary: {
         screen: GlossaryStack,
-            navigationOptions: ()=> ({title: i18n.t('Glossary')}) }
+            navigationOptions: ()=> ({title: translate('drawerNavigator.glossary')}) }
 });
 
 // New in this version of React Native, must be referenced/returned
@@ -37,8 +33,3 @@ export default class DrawerNavigator extends Component {
           }}/>;
     }
 }
-
-i18n.translations = {
-    en: { Home: 'Home', Resources:  'Resources', Glossary: 'Glossary', PediatricPTSD: 'Pediatric PTSD', more:'more'},
-    es: { Home: 'Hogar', Resources: 'Recursos', Glossary: 'Glosario', PediatricPTSD: 'Pediátrico TEPT', more: 'más'},
-  };

--- a/components/FindHelpCard.js
+++ b/components/FindHelpCard.js
@@ -1,29 +1,28 @@
 import React, { Component } from 'react';
-import {Text} from 'react-native';
-import {Card, Button as CardButton} from 'react-native-elements';
-// react-native and react-native-elements each have their Button components.
-// To ensure we are using the correct one in the Card, I have imported Button as CardButton from elements
-
+import { Text } from 'react-native';
+import { Card, Button as CardButton } from 'react-native-elements';
 import NavigationService from './NavigationService';
+import translate from './translateService';
+
 // Card view component to be displayed on the main screen
 // We can now use the NavigationService to navigate to screens as seen below (NavigationService.navigate('WhateverScreen'))
 export default class FindHelpCard extends Component {
     render() {
         return(
         <Card
-            featuredTitle="Help Your Child Recover"
+            featuredTitle={translate('mainScreen.findHelpTitle')}
             image={require('../assets/FindWaysHelp.jpg')}
             accessible
-            accessibilityLabel="Photo of father reading a book to a baby on his lap.">
+            accessibilityLabel={translate('mainScreen.findHelpAccessLabel')}>
             <Text style={{ marginBottom: 5 }}>
-                Dealing with emotional reactions and injury care can be difficult. Find ways to help your child recover. 
+                {translate('mainScreen.findHelpCaption')} 
             </Text>
             <CardButton onPress={()=>NavigationService.navigate('FindHelp')}
                 buttonStyle={{ borderRadius: 0, marginLeft: 0, marginRight: 0, marginBottom: 0 }}
-                title='FIND HELP' 
+                title={translate('mainScreen.findHelpButton')} 
                 accessible
-                accessibilityLabel="Find Help"
-                accessibilityHint="Navigates to the find help screen"
+                accessibilityLabel={translate('mainScreen.findHelpButton')}
+                accessibilityHint={translate('mainScreen.findHelpAccessHint')}
                 />
         </Card>
         );

--- a/components/LearnMoreCard.js
+++ b/components/LearnMoreCard.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import {Text} from 'react-native';
 import {Card, Button as CardButton} from 'react-native-elements';
-import { translate } from './translateService';
 import NavigationService from './NavigationService';
+import translate from './translateService';
 
 // Card view component to be displayed on the main screen
 // We can now use the NavigationService to navigate to screens as seen below (NavigationService.navigate('WhateverScreen'))

--- a/components/LearnMoreCard.js
+++ b/components/LearnMoreCard.js
@@ -1,30 +1,29 @@
 import React, { Component } from 'react';
 import {Text} from 'react-native';
 import {Card, Button as CardButton} from 'react-native-elements';
-// react-native and react-native-elements each have their own Button components.
-// To ensure we are using the correct one in the Card, I have imported Button as CardButton from elements
-
+import { translate } from './translateService';
 import NavigationService from './NavigationService';
+
 // Card view component to be displayed on the main screen
 // We can now use the NavigationService to navigate to screens as seen below (NavigationService.navigate('WhateverScreen'))
 export default class LearnMoreCard extends Component {
     render() {
         return(
         <Card
-            featuredTitle='Learn More About Injury and Trauma'
+            featuredTitle={translate('mainScreen.learnTitle')}
             featuredTitleStyle={{textAlign:'center'}}
             image={require('../assets/LearnMoreMD.jpg')}
             accessible
-            accessibilityLabel="Photo of a doctor holding a stethoscope with their arms folded accross their chest.">
+            accessibilityLabel={translate('mainScreen.learnAccessLabel')}>
             <Text style={{ marginBottom: 5 }}>
-                Get up-to-date information and expert guidance to assist you and your injured child.
+                {translate('mainScreen.learnCaption')}
             </Text>
             <CardButton onPress={()=>NavigationService.navigate('LearnMore')}
                 buttonStyle={{ borderRadius: 0, marginLeft: 0, marginRight: 0, marginBottom: 0 }}
-                title='LEARN MORE' 
+                title={translate('mainScreen.learnButton')} 
                 accessible
-                accessibilityLabel="Learn More"
-                accessibilityHint="Navigates to the learn more screen"/>
+                accessibilityLabel={translate('mainScreen.learnButton')}
+                accessibilityHint={translate('mainScreen.learnAccessHint')}/>
         </Card>
         );
     }

--- a/components/QuizCard.js
+++ b/components/QuizCard.js
@@ -1,28 +1,27 @@
 import React, { Component } from 'react';
 import {Text} from 'react-native';
 import {Card, Button as CardButton} from 'react-native-elements';
-// react-native and react-native-elements each have their Button components.
-// To ensure we are using the correct one in the Card, I have imported Button as CardButton from elements
 import NavigationService from '../components/NavigationService';
+import translate from './translateService';
 
-// Card view component to be displayed on the main screen
+// Card view component: to be displayed on the main screen
 export default class QuizCard extends Component {
     render() {
         return(
         <Card
-            featuredTitle="Rate Your Child's Reactions"
+            featuredTitle={translate('mainScreen.quizTitle')}
             image={require('../assets/QuizRateReactions.jpg')}
             accessible
-            accessibilityLabel="Photo of child covering her eyes with her hands.">
+            accessibilityLabel={translate('mainScreen.quizAccessLabel')}>
             <Text style={{ marginBottom: 5 }}>
-                An injury or accident can be a scary or stressful experience. Take a quick quiz to measure your child's traumatic stress.
+                {translate('mainScreen.quizCaption')}
             </Text>
             <CardButton onPress={()=>NavigationService.navigate('Quiz')}
                 buttonStyle={{ borderRadius: 0, marginLeft: 0, marginRight: 0, marginBottom: 0 }}
-                title='TAKE THE QUIZ' 
+                title={translate('mainScreen.quizButton')} 
                 accessible
-                accessibilityLabel="Take the Quiz"
-                accessibilityHint="Navigates to the quiz screen"/>
+                accessibilityLabel={translate('mainScreen.quizButton')}
+                accessibilityHint={translate('mainScreen.quizHint')}/>
         </Card>
         );
     }

--- a/components/translateService.js
+++ b/components/translateService.js
@@ -1,0 +1,16 @@
+import i18n from 'i18n-js';
+import en from '../languages/en.json';
+import es from '../languages/es.json';
+
+i18n.fallbacks = true;
+
+i18n.translations = {
+  en,
+  es
+};
+
+export function translate(text, params = {}) {
+  return i18n.t(text, params);
+};
+
+export default translate;

--- a/languages/en.json
+++ b/languages/en.json
@@ -13,6 +13,14 @@
         "learnAcessLabel": "Photo of a doctor holding a stethoscope with their arms folded accross their chest.",
         "learnAccessHint": "Navigates to the learn more screen",
         "quizButton": "TAKE THE QUIZ",
-        "findHelpButton": "FIND HELP"
+        "quizTitle": "Rate Your Child's Reactions",
+        "quizCaption": "An injury or accident can be a scary or stressful experience. Take a quick quiz to measure your child's traumatic stress.",
+        "quizAccessLabel": "Photo of child covering her eyes with her hands",
+        "quizAccessHint": "Navigates to the quiz screen",
+        "findHelpButton": "FIND HELP",
+        "findHelpTitle": "Help Your Child Recover",
+        "findHelpCaption": "Dealing with emotional reactions and injury care can be difficult. Find ways to help your child recover.",
+        "findHelpAccessLabel": "Photo of father reading a book to a baby on his lap.",
+        "findHelpAccessHint": "Navigates to the find help screen"
     }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,0 +1,9 @@
+{
+    "drawerNavigator": {
+        "home": "Home", 
+        "resources": "Resources", 
+        "glossary": "Glossary", 
+        "pediatricPTSD": "Pediatric PTSD", 
+        "more": "more"
+    }
+}

--- a/languages/en.json
+++ b/languages/en.json
@@ -2,8 +2,17 @@
     "drawerNavigator": {
         "home": "Home", 
         "resources": "Resources", 
-        "glossary": "Glossary", 
+        "glossary": "Glossary" 
+    },
+    "mainScreen": {
         "pediatricPTSD": "Pediatric PTSD", 
-        "more": "more"
+        "more": "more",
+        "learnButton": "LEARN MORE",
+        "learnTitle":"Learn More About Injury and Trauma",
+        "learnCaption": "Get up-to-date information and expert guidance to assist you and your injured child.",
+        "learnAcessLabel": "Photo of a doctor holding a stethoscope with their arms folded accross their chest.",
+        "learnAccessHint": "Navigates to the learn more screen",
+        "quizButton": "TAKE THE QUIZ",
+        "findHelpButton": "FIND HELP"
     }
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -13,6 +13,14 @@
         "learnAcessLabel": "Foto de un médico sosteniendo un estetoscopio con los brazos cruzados sobre el pecho.",
         "learnAccessHint": "Navega a la pantalla para obtener más información.",
         "quizButton": "RESPONDER AL CUESTIONARIO",
-        "findHelpButton": "ENCONTRAR AYUDA"
+        "quizTitle": "Califique las reacciones de su hijo",
+        "quizCaption": "Una lesión o accidente puede ser una experiencia aterradora o estresante. Haga una prueba rápida para medir el estrés traumático de su hijo.",
+        "quizAccessLabel": "Foto del niño cubriéndose los ojos con las manos",
+        "quizAccessHint": "Navega a la pantalla de prueba",
+        "findHelpButton": "ENCONTRAR AYUDA",
+        "findHelpTitle": "Ayude a su hijo a recuperarse",
+        "findHelpCaption": "Lidiar con las reacciones emocionales y cuidar las lesiones puede ser difícil. Encuentre maneras de ayudar a su hijo a recuperarse.",
+        "findHelpAccessLabel": "Foto del padre leyendo un libro a un bebé en su regazo.",
+        "findHelpAccessHint": "Navega para encontrar más ayuda"
     }
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -1,0 +1,9 @@
+{
+    "drawerNavigator": {
+        "home": "Hogar", 
+        "resources": "Recursos", 
+        "glossary": "Glosario", 
+        "pediatricPTSD": "Pediátrico TEPT", 
+        "more": "más"
+    }
+}

--- a/languages/es.json
+++ b/languages/es.json
@@ -2,8 +2,17 @@
     "drawerNavigator": {
         "home": "Hogar", 
         "resources": "Recursos", 
-        "glossary": "Glosario", 
+        "glossary": "Glosario"
+    },
+    "mainScreen": {
         "pediatricPTSD": "Pediátrico TEPT", 
-        "more": "más"
+        "more": "más",
+        "learnButton": "APRENDE MÁS",
+        "learnTitle":"Aprenda Más Sobre Lesiones y Traumas",
+        "learnCaption": "Obtenga información actualizada y orientación experta para ayudarlo a usted y a su hijo lesionado.",
+        "learnAcessLabel": "Foto de un médico sosteniendo un estetoscopio con los brazos cruzados sobre el pecho.",
+        "learnAccessHint": "Navega a la pantalla para obtener más información.",
+        "quizButton": "RESPONDER AL CUESTIONARIO",
+        "findHelpButton": "ENCONTRAR AYUDA"
     }
 }

--- a/mainAndLists/MainScreen.js
+++ b/mainAndLists/MainScreen.js
@@ -9,7 +9,7 @@ import i18n from 'i18n-js';
 import { translate } from '../components/translateService';
 
 
-// Set users locale for i18n translation
+// Set users locale for i18n translation throughout the application
 i18n.locale = Localization.locale;
 
     // I have learned that Props will become deprecated soon, this code has been changed to follow the
@@ -18,10 +18,10 @@ i18n.locale = Localization.locale;
 class MainScreen extends Component {
 
     static navigationOptions = () => ({
-        headerTitle: translate('drawerNavigator.pediatricPTSD'),
+        headerTitle: translate('mainScreen.pediatricPTSD'),
         headerLeft: (<View style={{ margin: 5 }}><Button 
             onPress={()=>NavigationService.openDrawer()}
-            title={translate('drawerNavigator.more')}></Button></View>)
+            title={translate('mainScreen.more')}></Button></View>)
     })
 
     render() {

--- a/mainAndLists/MainScreen.js
+++ b/mainAndLists/MainScreen.js
@@ -6,10 +6,11 @@ import FindHelpCard from '../components/FindHelpCard';
 import NavigationService from '../components/NavigationService';
 import * as Localization from 'expo-localization';
 import i18n from 'i18n-js';
+import { translate } from '../components/translateService';
 
-// Get users locale setting for i18n translation
+
+// Set users locale for i18n translation
 i18n.locale = Localization.locale;
-i18n.fallbacks = true;
 
     // I have learned that Props will become deprecated soon, this code has been changed to follow the
     // new best practice in React (to hopefully avoid features breaking in future updates).
@@ -17,10 +18,10 @@ i18n.fallbacks = true;
 class MainScreen extends Component {
 
     static navigationOptions = () => ({
-        headerTitle: i18n.t('PediatricPTSD'),
+        headerTitle: translate('drawerNavigator.pediatricPTSD'),
         headerLeft: (<View style={{ margin: 5 }}><Button 
             onPress={()=>NavigationService.openDrawer()}
-            title={i18n.t('more')}></Button></View>)
+            title={translate('drawerNavigator.more')}></Button></View>)
     })
 
     render() {
@@ -33,11 +34,6 @@ class MainScreen extends Component {
         );
     }
 }
-
-i18n.translations = {
-    en: { PediatricPTSD: 'Pediatric PTSD', more: 'more'},
-    es: { PediatricPTSD: 'Pediátrico TEPT', more: 'más'},
-  };
 
 export default MainScreen;
 

--- a/mainAndLists/MainScreen.js
+++ b/mainAndLists/MainScreen.js
@@ -5,6 +5,11 @@ import QuizCard from '../components/QuizCard';
 import FindHelpCard from '../components/FindHelpCard';
 import NavigationService from '../components/NavigationService';
 import * as Localization from 'expo-localization';
+import i18n from 'i18n-js';
+
+// Get users locale setting for i18n translation
+i18n.locale = Localization.locale;
+i18n.fallbacks = true;
 
     // I have learned that Props will become deprecated soon, this code has been changed to follow the
     // new best practice in React (to hopefully avoid features breaking in future updates).
@@ -12,15 +17,13 @@ import * as Localization from 'expo-localization';
 class MainScreen extends Component {
 
     static navigationOptions = () => ({
-        headerTitle: 'Pediatric PTSD',
+        headerTitle: i18n.t('PediatricPTSD'),
         headerLeft: (<View style={{ margin: 5 }}><Button 
             onPress={()=>NavigationService.openDrawer()}
-            title='More'></Button></View>)
+            title={i18n.t('more')}></Button></View>)
     })
 
     render() {
-        // Test that users local is correctly returned.
-        console.log(Localization.locale)
         return (
             <ScrollView>
                     <LearnMoreCard />
@@ -32,3 +35,9 @@ class MainScreen extends Component {
 }
 
 export default MainScreen;
+
+i18n.translations = {
+    en: { PediatricPTSD: 'Pediatric PTSD', more: 'more'},
+    es: { PediatricPTSD: 'Pediátrico TEPT', more: 'más'},
+  };
+

--- a/mainAndLists/MainScreen.js
+++ b/mainAndLists/MainScreen.js
@@ -34,10 +34,11 @@ class MainScreen extends Component {
     }
 }
 
-export default MainScreen;
-
 i18n.translations = {
     en: { PediatricPTSD: 'Pediatric PTSD', more: 'more'},
     es: { PediatricPTSD: 'Pediátrico TEPT', more: 'más'},
   };
+
+export default MainScreen;
+
 

--- a/mainAndLists/MainScreen.js
+++ b/mainAndLists/MainScreen.js
@@ -1,14 +1,14 @@
 import React, { Component } from "react";
 import { View, Button, ScrollView } from "react-native";
-
 import LearnMoreCard from '../components/LearnMoreCard';
 import QuizCard from '../components/QuizCard';
 import FindHelpCard from '../components/FindHelpCard';
-
 import NavigationService from '../components/NavigationService';
+import * as Localization from 'expo-localization';
+
     // I have learned that Props will become deprecated soon, this code has been changed to follow the
     // new best practice in React (to hopefully avoid features breaking in future updates).
-    // NavigationService is a new file I created, allowing me to use the openDrawer function.
+    // NavigationService is a new file I created, allowing us to use the openDrawer function.
 class MainScreen extends Component {
 
     static navigationOptions = () => ({
@@ -18,9 +18,9 @@ class MainScreen extends Component {
             title='More'></Button></View>)
     })
 
-    // Because we want the image, button and text to fit the width, the cards can only shrink so much.
-    // I wrapped the Card's in a scrollview so that users on smaller screens can still access everything
     render() {
+        // Test that users local is correctly returned.
+        console.log(Localization.locale)
         return (
             <ScrollView>
                     <LearnMoreCard />

--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,6 +3648,11 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
       "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
     },
+    "i18n-js": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-3.5.1.tgz",
+      "integrity": "sha512-nJgbE5Vj9qzOQfjdVd/uoMoO8ppVaB/3LB6KOmMfD8IQ1vNNh307iHyQLK8ZnLYWkAszfPvVpYmUt1Le/RuHMQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,6 +2593,14 @@
       "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-7.0.0.tgz",
       "integrity": "sha512-8VrFWR9tpXrDmk0kMyIpo6C5jKiDRzXPZN55JtyPhjuN1kF8Kle4d9ybNtV+bYd3Ql6PAZXY8Y/bhLAuWv0L9g=="
     },
+    "expo-localization": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-7.0.0.tgz",
+      "integrity": "sha512-DD391wtG+G4L/w3YndmSA+sOlRN5xpiIcwKcFYa+Tn5NIuHEds9G9JoqUo0wbqjirHBNTHfpFXWQ4NOGiKRLxg==",
+      "requires": {
+        "rtl-detect": "^1.0.2"
+      }
+    },
     "expo-location": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-7.0.0.tgz",
@@ -6081,6 +6089,11 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
       "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+    },
+    "rtl-detect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.0.2.tgz",
+      "integrity": "sha512-5X1422hvphzg2a/bo4tIDbjFjbJUOaPZwqE6dnyyxqwFqfR+tBcvfqapJr0o0VygATVCGKiODEewhZtKF+90AA=="
     },
     "run-async": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-web": "^0.11.7",
     "react-navigation": "^4.0.10",
     "react-navigation-drawer": "^2.2.2",
-    "react-navigation-stack": "^1.9.4"
+    "react-navigation-stack": "^1.9.4",
+    "expo-localization": "~7.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "expo": "^35.0.0",
     "expo-av": "~7.0.0",
     "expo-constants": "^7.0.1",
+    "expo-localization": "~7.0.0",
+    "i18n-js": "^3.5.1",
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
@@ -26,8 +28,7 @@
     "react-native-web": "^0.11.7",
     "react-navigation": "^4.0.10",
     "react-navigation-drawer": "^2.2.2",
-    "react-navigation-stack": "^1.9.4",
-    "expo-localization": "~7.0.0"
+    "react-navigation-stack": "^1.9.4"
   },
   "devDependencies": {
     "babel-preset-expo": "^7.0.0"


### PR DESCRIPTION
Implemented translateService.js for easy translation on all screens. 
As MainScreen is the entry point of the application, users locale is set for i18n use throughout the application.

Tested on Android in both English and Spanish. Appears to be working correctly.
Locale fallback was tested and also working as intended, it will even fallback if only a section of text is missing a Spanish translation (instead of the missing translation error I saw some team members experiencing). It will only fallback that specific text, the rest of the application remains in Spanish. 
