### PR TITLE
US221T270: translate 'back' header for iOS users

### DIFF
--- a/components/StackNavigator.js
+++ b/components/StackNavigator.js
@@ -18,6 +18,7 @@ import HealthcareTeam from '../findHelpScreens/HealthcareTeamScreens/HealthcareT
 import SelfCare from '../findHelpScreens/selfCareScreens/SelfCare';
 import QuizMain from '../QuizScreens/QuizMain';
 import QuizResults from '../QuizScreens/QuizResults';
+import translate from './translateService';
 
 // StackNavigator: This navigator controls the flow from the main screen to other screens and back (Stack)
 // This is called by the DrawerNavigator, so it is sort of nested inside
@@ -26,7 +27,7 @@ const NavigationBar = createStackNavigator({
     LearnMore: LearnMoreList,
     FindHelp: FindHelpList,
     Quiz: QuizMain,
-    QuizResults: QuizResults, // un-comment when page is ready to test
+    QuizResults: QuizResults,
     NotAlone: YoureNotAlone,
     Reactions: ReactionsToInjury,
     TraumaticStressReactions: TraumaticStressReactions,
@@ -38,6 +39,11 @@ const NavigationBar = createStackNavigator({
     HowToTalk: HowToTalk,
     QuickTips: QuickTips,
     SelfCare: SelfCare
+    },
+    {
+    defaultNavigationOptions: { 
+       headerTruncatedBackTitle: translate('mainScreen.backButton'),
+    }
   });
   
   // New in this version of React Native, must be created and reference/returned

--- a/languages/en.json
+++ b/languages/en.json
@@ -38,7 +38,7 @@
         "glossary": "Glossary"
     },
     "glossary": {
-        "back": "Back",
+        "back": "BACK",
         "glossary": "Glossary",
         "description": "Find word definitions by category.",
         "accordion": [
@@ -778,8 +778,9 @@
         "whatToExpect": "WHAT TO EXPECT AFTER INJURY"
     },
     "mainScreen": {
+        "backButton": "BACK",
         "pediatricPTSD": "Pediatric PTSD",
-        "more": "more",
+        "more": "MORE",
         "learnButton": "LEARN MORE",
         "learnTitle": "Learn More About Injury and Trauma",
         "learnCaption": "Get up-to-date information and expert guidance to assist you and your injured child.",
@@ -942,7 +943,7 @@
         }
     },
     "resources": { 
-        "back": "Back",
+        "back": "BACK",
         "resources": "Resources",
         "description": "Find additional resources for you and your child.",
         "accessibilityHint": "Photo of multi-layered pyramid.",

--- a/languages/es.json
+++ b/languages/es.json
@@ -38,7 +38,7 @@
         "glossary": "Glosario"
     },
     "glossary": {
-        "back": "Regreso",
+        "back": "REGRESO",
         "glossary": "Glosario",
         "description": "Encuentra definiciones de palabras por categoría",
         "accordion": [
@@ -777,8 +777,9 @@
         "whatToExpect": "QUÉ ESPERAR DESPUÉS DE LESIÓN"
     },
     "mainScreen": {
+        "backButton": "REGRESO",
         "pediatricPTSD": "Pediátrico TEPT",
-        "more": "más",
+        "more": "MÁS",
         "learnButton": "APRENDE MÁS",
         "learnTitle": "Aprenda Más Sobre Lesiones y Traumas",
         "learnCaption": "Obtenga información actualizada y orientación experta para ayudarlo a usted y a su hijo lesionado.",
@@ -941,7 +942,7 @@
         }
     },
     "resources": {
-        "back": "Regreso",
+        "back": "REGRESO",
         "resources": "Recursos",
         "description": "Encuentre recursos adicionales para ayudarlo a usted y a su hijo.",
         "accessibilityHint": "Una foto de una pirámide en capas.",


### PR DESCRIPTION
When stepping forward in navigation, iOS displays a chevron with text that acts as a button to return to the previous screen in the navigator. With long text, iOS defaults the text to 'BACK.' 

I have added a default option to the navigator (headerTruncatedBackTitle) that should use our proper i18n translation of either BACK or REGRESO, depending on language. 

I don't have a MacBook or iOS product to test this is working. I tested the code on Android and everything ran as normal (as expected).